### PR TITLE
FFT looping

### DIFF
--- a/src/iqwaveform/fourier.py
+++ b/src/iqwaveform/fourier.py
@@ -165,7 +165,7 @@ def _iter_along_axes(x: ArrayType, axes: typing.Iterable[int] | None) -> typing.
     ax_inds = []
     for i in range(x.ndim):
         if i in axes:
-            ax_inds.append(range(x.shape[i]))
+            ax_inds.append(((n,) for n in range(x.shape[i])))
         else:
             ax_inds.append((empty_slice,))
     

--- a/src/iqwaveform/fourier.py
+++ b/src/iqwaveform/fourier.py
@@ -173,13 +173,15 @@ def _cupy_fftn_helper(
     # TODO: see about upstream question on this
     if out is None:
         if iter_axes is not None:
-            raise ValueError('set out to a buffer target unless loop axes requires')
+            raise ValueError('must pass an output buffer to use iter_axes')
         return cp.fft._fft._fftn(x, out=out, *args, **kws)
     else:
         out = out.reshape(x.shape)
+        if iter_axes is not None:
+            kws['overwrite_x'] = False
 
     for itup in inds:
-        out[itup] = cp.fft._fft._fftn(x[itup], out=out[itup], *args, **kws)
+        cp.fft._fft._fftn(x[itup], out=out[itup], *args, **kws)
 
     return out
 

--- a/src/iqwaveform/fourier.py
+++ b/src/iqwaveform/fourier.py
@@ -155,7 +155,7 @@ def _truncated_buffer(x: ArrayType, shape, dtype=None):
 
 def _iterate_on_axes(x: ArrayType, axes: typing.Iterable[int] | None):
     if axes is None:
-        return slice(None, None)
+        return (slice(None, None),)
     elif isinstance(axes, numbers.Number):
         axes = (axes,)
 

--- a/src/iqwaveform/fourier.py
+++ b/src/iqwaveform/fourier.py
@@ -177,11 +177,9 @@ def _cupy_fftn_helper(
         return cp.fft._fft._fftn(x, out=out, *args, **kws)
     else:
         out = out.reshape(x.shape)
-        if iter_axes is not None:
-            kws['overwrite_x'] = False
 
     for itup in inds:
-        cp.fft._fft._fftn(x[itup], out=out[itup], *args, **kws)
+        out[itup] = cp.fft._fft._fftn(x[itup], out=out[itup], *args, **kws)
 
     return out
 

--- a/src/iqwaveform/fourier.py
+++ b/src/iqwaveform/fourier.py
@@ -153,15 +153,23 @@ def _truncated_buffer(x: ArrayType, shape, dtype=None):
     return x.flatten()[:out_size].reshape(shape)
 
 
-def _iter_along_axes(x: ArrayType, axes: typing.Iterable[int] | None):
+def _iter_along_axes(x: ArrayType, axes: typing.Iterable[int] | None) -> typing.Iterable[tuple[int, ...]]:
+    empty_slice = slice(None, None)
     if axes is None:
-        return (slice(None, None),)
+        return (empty_slice,)
     elif isinstance(axes, numbers.Number):
         axes = (axes,)
 
     axes = [(ax if ax >= 0 else ax + x.ndim) for ax in axes]
-    ax_iters = ((range(x.shape[i]) if i in axes else [None]) for i in range(x.ndim))
-    return itertools.product(*ax_iters)
+
+    ax_inds = []
+    for i in range(x.ndim):
+        if i in axes:
+            ax_inds.append(range(x.shape[i]))
+        else:
+            ax_inds.append((empty_slice,))
+    
+    return itertools.product(*ax_inds)
 
 
 def fft(

--- a/src/iqwaveform/fourier.py
+++ b/src/iqwaveform/fourier.py
@@ -174,7 +174,7 @@ def fft(
 
         args = (None,), (axis,), None, cp.cuda.cufft.CUFFT_FORWARD
         kws = dict(
-            cp.cuda.cufft.CUFFT_FORWARD, overwrite_x=overwrite_x, plan=plan, order='C'
+            overwrite_x=overwrite_x, plan=plan, order='C'
         )
 
         # TODO: see about upstream question on this
@@ -214,7 +214,7 @@ def ifft(
 
         args = (None,), (axis,), None, cp.cuda.cufft.CUFFT_FORWARD
         kws = dict(
-            cp.cuda.cufft.CUFFT_INVERSE, overwrite_x=overwrite_x, plan=plan, order='C'
+            overwrite_x=overwrite_x, plan=plan, order='C'
         )
 
         # TODO: see about upstream question on this

--- a/src/iqwaveform/fourier.py
+++ b/src/iqwaveform/fourier.py
@@ -183,7 +183,7 @@ def fft(
                 raise ValueError('set out to a buffer target unless loop axes requires')
             return cp.fft._fft._fftn(x, out=out, *args, **kws)
         else:
-            out = out.reshape(x.shape, copy=False)
+            out = out.reshape(x.shape)
 
         for itup in inds:
             cp.fft._fft._fftn(x[itup], out=out[itup], *args, **kws)
@@ -223,7 +223,7 @@ def ifft(
                 raise ValueError('set out to a buffer target unless loop axes requires')
             return cp.fft._fft._fftn(x, out=out, *args, **kws)
         else:
-            out = out.reshape(x.shape, copy=False)
+            out = out.reshape(x.shape)
 
         for itup in inds:
             cp.fft._fft._fftn(x[itup], out=out[itup], *args, **kws)

--- a/src/iqwaveform/fourier.py
+++ b/src/iqwaveform/fourier.py
@@ -153,7 +153,7 @@ def _truncated_buffer(x: ArrayType, shape, dtype=None):
     return x.flatten()[:out_size].reshape(shape)
 
 
-def _cupy_nfft_helper(
+def _cupy_fftn_helper(
     x,
     axis,
     direction,
@@ -179,7 +179,7 @@ def _cupy_nfft_helper(
         out = out.reshape(x.shape)
 
     for itup in inds:
-        cp.fft._fft._fftn(x[itup], out=out[itup], *args, **kws)
+        out[itup] = cp.fft._fft._fftn(x[itup], out=out[itup], *args, **kws)
 
     return out
 
@@ -190,7 +190,7 @@ def fft(
     if is_cupy_array(x):
         import cupy as cp
 
-        return _cupy_nfft_helper(
+        return _cupy_fftn_helper(
             x,
             axis=axis,
             direction=cp.cuda.cufft.CUFFT_FORWARD,
@@ -220,7 +220,7 @@ def ifft(
     if is_cupy_array(x):
         import cupy as cp
 
-        return _cupy_nfft_helper(
+        return _cupy_fftn_helper(
             x,
             axis=axis,
             direction=cp.cuda.cufft.CUFFT_INVERSE,

--- a/src/iqwaveform/util.py
+++ b/src/iqwaveform/util.py
@@ -491,7 +491,9 @@ def dtype_change_float(dtype, float_basis_dtype) -> np.dtype:
     )
 
 
-def iter_along_axes(x: type_stubs.ArrayType, axes: typing.Iterable[int] | None) -> typing.Iterable[tuple[int, ...]]:
+def iter_along_axes(
+    x: type_stubs.ArrayType, axes: typing.Iterable[int] | None
+) -> typing.Iterable[tuple[int, ...]]:
     empty_slice = slice(None, None)
     if axes is None:
         return (empty_slice,)
@@ -506,5 +508,5 @@ def iter_along_axes(x: type_stubs.ArrayType, axes: typing.Iterable[int] | None) 
             ax_inds.append(((n,) for n in range(x.shape[i])))
         else:
             ax_inds.append((empty_slice,))
-    
+
     return itertools.product(*ax_inds)


### PR DESCRIPTION
The memory expense of cupy _nfft calls on the tested hardware seems to increase nonlinearly with the total size of the input, not just the size of the FFT axis. This implements crude for-loop implementation of the fft in order to mitigate the problem.